### PR TITLE
Add PHP 8.4 support and require PHP 8.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.3', '8.4']
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "ext-intl": "*",
-        "php": "^7.4|^8.0",
+        "php": "^8.3",
         "symfony/framework-bundle": "^6.0|^7.0",
         "assoconnect/php-date": "^2.11",
         "doctrine/dbal": "^2.10|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
     },
     "require-dev": {
         "symfony/contracts": "^2.4",
-        "symfony/translation": "^6.0|^7.0",
+        "symfony/translation": "^7.0",
         "assoconnect/php-quality-config": "^1.16",
         "assoconnect/validator-bundle": "^2.19"
     },
     "require": {
         "ext-intl": "*",
         "php": "^8.3",
-        "symfony/framework-bundle": "^6.0|^7.0",
+        "symfony/framework-bundle": "^7.0",
         "assoconnect/php-date": "^2.11",
         "doctrine/dbal": "^2.10|^3.0",
-        "symfony/serializer": "^6.0|^7.0",
+        "symfony/serializer": "^7.0",
         "twig/twig": "^3",
-        "symfony/clock": "^6.4|^7.3"
+        "symfony/clock": "^7.3"
     },
     "config": {
         "allow-plugins": {

--- a/src/AbsoluteDateClock.php
+++ b/src/AbsoluteDateClock.php
@@ -17,7 +17,7 @@ class AbsoluteDateClock
     /**
      * @throws \DateMalformedStringException
      */
-    public static function relative(string $relative = 'now', \DateTimeZone $timezone = null): AbsoluteDate
+    public static function relative(string $relative = 'now', ?\DateTimeZone $timezone = null): AbsoluteDate
     {
         return AbsoluteDate::createInTimezone($timezone ?? new \DateTimeZone('UTC'), new DatePoint($relative));
     }

--- a/src/AbsoluteDateClock.php
+++ b/src/AbsoluteDateClock.php
@@ -5,20 +5,18 @@ declare(strict_types=1);
 namespace AssoConnect\PHPDateBundle;
 
 use AssoConnect\PHPDate\AbsoluteDate;
+use DateTimeZone;
 use Symfony\Component\Clock\DatePoint;
 
 class AbsoluteDateClock
 {
-    public static function now(\DateTimeZone $timeZone = null): AbsoluteDate
+    public static function now(?DateTimeZone $timeZone = null): AbsoluteDate
     {
         return self::relative('now', $timeZone);
     }
 
-    /**
-     * @throws \DateMalformedStringException
-     */
-    public static function relative(string $relative = 'now', ?\DateTimeZone $timezone = null): AbsoluteDate
+    public static function relative(string $relative = 'now', ?DateTimeZone $timezone = null): AbsoluteDate
     {
-        return AbsoluteDate::createInTimezone($timezone ?? new \DateTimeZone('UTC'), new DatePoint($relative));
+        return AbsoluteDate::createInTimezone($timezone ?? new DateTimeZone('UTC'), new DatePoint($relative));
     }
 }

--- a/src/Normalizer/AbsoluteDateNormalizer.php
+++ b/src/Normalizer/AbsoluteDateNormalizer.php
@@ -24,7 +24,7 @@ class AbsoluteDateNormalizer implements NormalizerInterface, DenormalizerInterfa
      * @param mixed[] $context
      * @throws InvalidArgumentException
      */
-    public function normalize($object, string $format = null, array $context = []): string
+    public function normalize($object, ?string $format = null, array $context = []): string
     {
         if (!$object instanceof AbsoluteDate) {
             throw new InvalidArgumentException(sprintf(
@@ -42,7 +42,7 @@ class AbsoluteDateNormalizer implements NormalizerInterface, DenormalizerInterfa
      * {@inheritdoc}
      * @param mixed[] $context
      */
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof AbsoluteDate;
     }
@@ -53,7 +53,7 @@ class AbsoluteDateNormalizer implements NormalizerInterface, DenormalizerInterfa
      * @param mixed[] $context
      * @throws NotNormalizableValueException
      */
-    public function denormalize($data, string $type, string $format = null, array $context = []): ?AbsoluteDate
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): ?AbsoluteDate
     {
         $dateTimeFormat = $context[self::FORMAT_KEY] ?? AbsoluteDate::DEFAULT_DATE_FORMAT;
 

--- a/src/Normalizer/AbsoluteDateNormalizer.php
+++ b/src/Normalizer/AbsoluteDateNormalizer.php
@@ -24,9 +24,9 @@ class AbsoluteDateNormalizer implements NormalizerInterface, DenormalizerInterfa
      * @param mixed[] $context
      * @throws InvalidArgumentException
      */
-    public function normalize($object, ?string $format = null, array $context = []): string
+    public function normalize(mixed $data, ?string $format = null, array $context = []): string
     {
-        if (!$object instanceof AbsoluteDate) {
+        if (!$data instanceof AbsoluteDate) {
             throw new InvalidArgumentException(sprintf(
                 'The object must be an instance of "%s".',
                 AbsoluteDate::class
@@ -35,7 +35,7 @@ class AbsoluteDateNormalizer implements NormalizerInterface, DenormalizerInterfa
 
         $dateTimeFormat = $context[self::FORMAT_KEY] ?? AbsoluteDate::DEFAULT_DATE_FORMAT;
 
-        return $object->format($dateTimeFormat);
+        return $data->format($dateTimeFormat);
     }
 
     /**

--- a/src/Translatable/AbsoluteDateTranslatable.php
+++ b/src/Translatable/AbsoluteDateTranslatable.php
@@ -34,7 +34,7 @@ class AbsoluteDateTranslatable implements TranslatableInterface
         $this->timezone = new DateTimeZone('UTC');
     }
 
-    public function trans(TranslatorInterface $translator, string $locale = null): string
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
     {
         if (null === $locale) {
             $locale = $translator->getLocale();

--- a/src/Twig/Extension/AbsoluteDateExtension.php
+++ b/src/Twig/Extension/AbsoluteDateExtension.php
@@ -26,7 +26,7 @@ class AbsoluteDateExtension extends AbstractExtension
         ];
     }
 
-    public function formatAbsoluteDate(AbsoluteDate $date, string $locale = null): string
+    public function formatAbsoluteDate(AbsoluteDate $date, ?string $locale = null): string
     {
         return (new AbsoluteDateTranslatable($date))->trans($this->translator, $locale);
     }


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement to 8.3
- Add PHP 8.4 to CI test matrix

## Changes
- Update composer.json to require PHP ^8.3
- Update GitHub Actions workflow to test on PHP 8.3 and 8.4
- Removing support for Symfony 6

## Related
Part of organization-wide upgrade to standardize on PHP 8.3+ across all packages.

## Test plan
- [ ] CI tests pass on PHP 8.3
- [ ] CI tests pass on PHP 8.4