### PR TITLE
Upgrade PHPUnit configuration to version 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "symfony/contracts": "^2.4",
         "symfony/translation": "^7.0",
-        "assoconnect/php-quality-config": "^2",
+        "assoconnect/php-quality-config": "^2.2",
         "assoconnect/validator-bundle": "^2.39.2"
     },
     "require": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="main">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
   <testsuites>
     <testsuite name="main">
       <directory>./tests/</directory>

--- a/tests/Doctrine/DBAL/Types/AbsoluteDateTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/AbsoluteDateTypeTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 use function date_default_timezone_set;
 
-class DateTest extends TestCase
+class AbsoluteDateTypeTest extends TestCase
 {
     /** @var AbstractPlatform|MockObject */
     protected AbstractPlatform $platform;


### PR DESCRIPTION
## Summary
- Updates `phpunit.xml.dist` to use PHPUnit 10 schema
- Moves source directory configuration from `<coverage>` to `<source>` (PHPUnit 10 format)
- Removes deprecated `processUncoveredFiles` attribute
- Renames `DateTest` class to `AbsoluteDateTypeTest` to match file name (PHPUnit 10 requirement)

Note: The class rename also fixes a bug where only 23 tests were running instead of 42 — `AbsoluteDateTypeTest.php` was silently skipped because the class name didn't match.

## Test plan
- [ ] All PHPUnit tests pass (42 tests, was 23 before fix)
- [ ] phpcs passes
- [ ] phpstan passes
- [ ] rector --dry-run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)