### PR TITLE
Upgrade analysis tools to latest on lowest dependency runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependency-versions }}
 
+      - name: Upgrade analysis tools to latest
+        if: ${{ matrix.dependency-versions == 'lowest' }}
+        run: composer update phpstan/phpstan rector/rector phpunit/phpunit squizlabs/php_codesniffer --with-all-dependencies --no-interaction
+
       - run: vendor/bin/phpcs
         if: ${{ failure() ||  success() }}
 


### PR DESCRIPTION
## Summary
When running with lowest Composer dependencies, force-upgrade phpstan, rector, phpunit and phpcs to their latest versions to avoid false failures caused by outdated tooling (e.g. phpcs not understanding typed class constants introduced in PHP 8.3).

## Test plan
- [ ] CI passes on lowest and highest dependency runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)